### PR TITLE
Fix patients exclusion code in sepsis_cohort.py

### DIFF
--- a/sepsis_cohort.py
+++ b/sepsis_cohort.py
@@ -956,7 +956,7 @@ reformat4t = reformat4t.loc[~ii]
 # Exclude patients who died in ICU during data collection period
 print('Full ICU -- excluding patients who died in ICU during data collection period')
 ii = (reformat4t['bloc'] == 1) & (reformat4t['died_within_48h_of_out_time'] == 1) & (reformat4t['delay_end_of_record_and_discharge_or_death'] < 24)
-ii = reformat4t['icustayid'][ii].isin(icustayidlist).index 
+ii = reformat4t['icustayid'][ii][reformat4t['icustayid'][ii].isin(icustayidlist)]
 ii = reformat4t['icustayid'].isin(ii)
 reformat4t = reformat4t.loc[~ii] 
 


### PR DESCRIPTION
In this block of code, we intended to exclude patients who died in ICU during the data collection period, but the actual implementation in lines 956-961 could not get work done. According to line 960 `ii = reformat4t['icustayid'].isin(ii)`, `ii` should be a list of `icustayid`'s for patients who died in ICU during the data collection period, but it was defined as a list of indexes in the previous line `reformat4t['icustayid'][ii].isin(icustayidlist).index`. Due to this mismatch, the target `icustayid`'s are not excluded, and hence this population is still kept in the dataset. To fix this, I modify line 959 to make `ii` a list of `icustayid`'s. 

After this fix, a sanity check `sum((reformat4t['died_within_48h_of_out_time'] == 1) & (reformat4t['delay_end_of_record_and_discharge_or_death'] < 24))` outputs 0, indicating that the target patients have been removed from the table.
